### PR TITLE
Remove unused variable in BacktrackingLineSearch class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,10 +137,10 @@ endif()
 if(UNGAR_INSTALL)
   include(GNUInstallDirs)
 
-  # Install library headers.
+  # Install Ungar headers.
   install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-  # Install library binaries.
+  # Install Ungar binaries.
   install(
     TARGETS ungar
     EXPORT ${PROJECT_NAME}Targets
@@ -150,7 +150,7 @@ if(UNGAR_INSTALL)
     INCLUDES
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-  # Install library configuration files.
+  # Install Ungar configuration files.
   include(CMakePackageConfigHelpers)
 
   configure_package_config_file(

--- a/include/ungar/optimization/backtracking_line_search.hpp
+++ b/include/ungar/optimization/backtracking_line_search.hpp
@@ -82,8 +82,7 @@ class BacktrackingLineSearch {
                           const Eigen::MatrixBase<_SearchDirection>& dw,
                           const Concepts::CostFunction<_W> auto& costFunction,
                           const Concepts::ConstraintViolation<_W> auto& constraintViolation,
-                          Eigen::MatrixBase<_W> const& w,
-                          const bool verbose = false) const {
+                          Eigen::MatrixBase<_W> const& w) const {
         UNGAR_ASSERT(costFunctionGradient.cols() == 1_idx);
         UNGAR_ASSERT(dw.cols() == 1_idx);
         UNGAR_ASSERT(costFunctionGradient.rows() == dw.rows());


### PR DESCRIPTION
Remove the unused function argument ```verbose``` from the ```BacktrackingLineSearch::Do``` function: the class initializes the verbosity level in the constructor.